### PR TITLE
Fix mixed plan generation

### DIFF
--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/calcula_plan.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/calcula_plan.php
@@ -187,7 +187,6 @@ $conexion->close();
 // Si el usuario cuenta con un plan mixto, continuamos con el formulario de
 // ejercicios; de lo contrario volvemos al panel principal.
 if ($plan === 3) {
-    header('Location: ../forms/guardar_ejercicios.php');
+    header('Location: ../widget/calcula_ejercicios.php');
 } else {
-    header('Location: ../pages/panel.php');
-}?>
+    header('Location: ../pages/panel.php');}?>


### PR DESCRIPTION
## Summary
- insert workout request automatically when saving nutrition data
- jump directly to exercise calculation for mixed plans

## Testing
- `php` syntax checker *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee90b89e483269cc94438a98d61ea