### PR TITLE
Implement session and role checks

### DIFF
--- a/able-pro-vanila-bootstrap-9.4.3/dist/auth/check_admin.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/auth/check_admin.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__.'/check_session.php';
+if (!isset($_SESSION['IdRol']) || $_SESSION['IdRol'] != 2) {
+    header('Location: ../pages/panel.php');
+    exit();
+}
+?>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/auth/check_session.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/auth/check_session.php
@@ -1,0 +1,9 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+if (!isset($_SESSION['IdUsuario'])) {
+    header('Location: ../index.php');
+    exit();
+}
+?>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/auth/logout.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/auth/logout.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: ../index.php');
+exit();
+?>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/auth/logout.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/auth/logout.php
@@ -1,6 +1,17 @@
 <?php
-session_start();
-session_unset();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Limpiar todas las variables de la sesión
+$_SESSION = [];
+
+// Destruir la cookie de sesión si existe
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+}
+
 session_destroy();
 header('Location: ../index.php');
 exit();

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
@@ -357,10 +357,10 @@ $notificationCount = count($notificaciones);
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
@@ -1,7 +1,7 @@
 <?php
 include('db.php');
 include('UsuarioClass.php');
-session_start();
+require_once '../auth/check_session.php';
 
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
@@ -8,14 +8,9 @@ $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
 
 
-$sql = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt = $conexion->prepare($sql);
-$stmt->bind_param("i", $_SESSION['IdUsuario']);
-$stmt->execute();
-$resultadoNotificaciones = $stmt->get_result();
+require_once '../widget/notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 
 <!doctype html>
@@ -123,7 +118,7 @@ $resultadoNotificaciones = $stmt->get_result();
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -273,7 +268,7 @@ $resultadoNotificaciones = $stmt->get_result();
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -292,43 +287,9 @@ $resultadoNotificaciones = $stmt->get_result();
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-      <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
     </li>
     <li class="dropdown pc-h-item header-user-profile">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/cuestionariohecho.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/cuestionariohecho.php
@@ -99,7 +99,7 @@
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -240,7 +240,7 @@
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/cuestionariohecho.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/cuestionariohecho.php
@@ -489,10 +489,10 @@
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
+              <a href="../auth/logout.php" class="btn btn-primary">
                 <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             <div
               class="card border-0 shadow-none drp-upgrade-card mb-0"

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
@@ -326,10 +326,10 @@ $notificationCount = count($notificaciones);
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
@@ -1,7 +1,7 @@
 <?php
 include('db.php');
 include('UsuarioClass.php');
-session_start();
+require_once '../auth/check_session.php';
 
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
@@ -8,6 +8,9 @@ $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
 // Determinar si se debe saltar la primera pestaña en caso de plan mixto
 $saltarDatosPersonales = ($datosUsuario["idTipoPlan"] == 3);
+require_once '../widget/notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 
 <!doctype html>
@@ -93,7 +96,7 @@ $saltarDatosPersonales = ($datosUsuario["idTipoPlan"] == 3);
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -235,7 +238,7 @@ $saltarDatosPersonales = ($datosUsuario["idTipoPlan"] == 3);
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -254,109 +257,9 @@ $saltarDatosPersonales = ($datosUsuario["idTipoPlan"] == 3);
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-        <div class="dropdown-header d-flex align-items-center justify-content-between">
-          <h5 class="m-0">Notifications</h5>
-          <a href="#!" class="btn btn-link btn-sm">Mark all read</a>
-        </div>
-        <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-          <p class="text-span">Today</p>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-layer"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">2 min ago</span>
-                  <h5 class="text-body mb-2">UI/UX Design</h5>
-                  <p class="mb-0"
-                    >Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
-                    type and scrambled it to make a type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-sms"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">1 hour ago</span>
-                  <h5 class="text-body mb-2">Message</h5>
-                  <p class="mb-0">Lorem Ipsum has been the industry's standard dummy text ever since the 1500.</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <p class="text-span">Yesterday</p>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-document-text"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">2 hour ago</span>
-                  <h5 class="text-body mb-2">Forms</h5>
-                  <p class="mb-0"
-                    >Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
-                    type and scrambled it to make a type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-user-bold"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">12 hour ago</span>
-                  <h5 class="text-body mb-2">Challenge invitation</h5>
-                  <p class="mb-2"><span class="text-dark">Jonny aber</span> invites to join the challenge</p>
-                  <button class="btn btn-sm btn-outline-secondary me-2">Decline</button>
-                  <button class="btn btn-sm btn-primary">Accept</button>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-security-safe"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">5 hour ago</span>
-                  <h5 class="text-body mb-2">Security</h5>
-                  <p class="mb-0"
-                    >Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
-                    type and scrambled it to make a type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="text-center py-2">
-          <a href="#!" class="link-danger">Clear all Notifications</a>
-        </div>
-      </div>
+      <?php render_notifications_dropdown($notificaciones); ?>
     </li>
     <li class="dropdown pc-h-item header-user-profile">
       <a

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/formulario.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/formulario.php
@@ -1,5 +1,5 @@
 <?php
-session_start(); // Iniciar sesión para manejar los datos
+require_once '../auth/check_session.php';
 
 // Identificar el formulario actual
 $formularioActual = isset($_POST['formularioActual']) ? $_POST['formularioActual'] : 1;

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/guardar_datos.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/guardar_datos.php
@@ -1,6 +1,6 @@
 <?php
 include 'db.php'; // Conexión a la base de datos
-session_start();    
+require_once '../auth/check_session.php';
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
 

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/guardar_ejercicios.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/guardar_ejercicios.php
@@ -1,6 +1,6 @@
 <?php
 include 'db.php';      // Conexión a la base de datos
-session_start();
+require_once '../auth/check_session.php';
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
 

--- a/able-pro-vanila-bootstrap-9.4.3/dist/foro/envioPreguntasForo.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/foro/envioPreguntasForo.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once '../auth/check_session.php';
 include '../../vendor/autoload.php';
 include '../widget/db.php';
 use PHPMailer\PHPMailer\PHPMailer;

--- a/able-pro-vanila-bootstrap-9.4.3/dist/foro/guardarNotificacion.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/foro/guardarNotificacion.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once '../auth/check_session.php';
 header('Content-Type: application/json; charset=utf-8');
 include('../widget/db.php');
 

--- a/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once '../auth/check_session.php';
 $IdUsuario = $_SESSION['IdUsuario'];
 include('../widget/db.php');
 include('../forms/UsuarioClass.php');

--- a/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
@@ -333,10 +333,10 @@ if ($row = $result->fetch_assoc()) {
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
@@ -97,7 +97,7 @@ if ($row = $result->fetch_assoc()) {
                     <i class="ph-duotone ph-sneaker-move f-28"></i>
                     <span>Plan de entrenamiento</span>
                   </a>
-                  <a href="#!">
+                  <a href="../auth/logout.php">
                     <i class="ti ti-power"></i>
                     <span>Cerrar Sesión</span>
                   </a>
@@ -245,7 +245,7 @@ if ($row = $result->fetch_assoc()) {
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -264,109 +264,9 @@ if ($row = $result->fetch_assoc()) {
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-        <div class="dropdown-header d-flex align-items-center justify-content-between">
-          <h5 class="m-0">Notifications</h5>
-          <a href="#!" class="btn btn-link btn-sm">Mark all read</a>
-        </div>
-        <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-          <p class="text-span">Today</p>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-layer"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">2 min ago</span>
-                  <h5 class="text-body mb-2">UI/UX Design</h5>
-                  <p class="mb-0"
-                    >Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
-                    type and scrambled it to make a type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-sms"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">1 hour ago</span>
-                  <h5 class="text-body mb-2">Message</h5>
-                  <p class="mb-0">Lorem Ipsum has been the industry's standard dummy text ever since the 1500.</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <p class="text-span">Yesterday</p>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-document-text"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">2 hour ago</span>
-                  <h5 class="text-body mb-2">Forms</h5>
-                  <p class="mb-0"
-                    >Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
-                    type and scrambled it to make a type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-user-bold"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">12 hour ago</span>
-                  <h5 class="text-body mb-2">Challenge invitation</h5>
-                  <p class="mb-2"><span class="text-dark">Jonny aber</span> invites to join the challenge</p>
-                  <button class="btn btn-sm btn-outline-secondary me-2">Decline</button>
-                  <button class="btn btn-sm btn-primary">Accept</button>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="card mb-2">
-            <div class="card-body">
-              <div class="d-flex">
-                <div class="flex-shrink-0">
-                  <svg class="pc-icon text-primary">
-                    <use xlink:href="#custom-security-safe"></use>
-                  </svg>
-                </div>
-                <div class="flex-grow-1 ms-3">
-                  <span class="float-end text-sm text-muted">5 hour ago</span>
-                  <h5 class="text-body mb-2">Security</h5>
-                  <p class="mb-0"
-                    >Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of
-                    type and scrambled it to make a type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="text-center py-2">
-          <a href="#!" class="link-danger">Clear all Notifications</a>
-        </div>
-      </div>
+      <?php render_notifications_dropdown($notificaciones); ?>
     </li>
     <li class="dropdown pc-h-item header-user-profile">
       <a

--- a/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once '../auth/check_session.php';
 include('../widget/db.php');
 include('../forms/UsuarioClass.php');
 
@@ -148,14 +148,16 @@ $resultadoNotificaciones = $stmt->get_result();
             <span class="pc-mtext">Mi Progreso</span>
           </a>
         </li>
+        <?php if(isset($_SESSION['IdRol']) && $_SESSION['IdRol'] == 2): ?>
         <li class="pc-item">
           <a href="../../dist/widget/w_paneladm.php" class="pc-link">
             <span class="pc-micon">
-              <img src="../assets/images/icons-tab/icons9.png" alt="Recetas">  
+              <img src="../assets/images/icons-tab/icons9.png" alt="Recetas">
             </span>
             <span class="pc-mtext">Panel de Administración</span>
           </a>
        </li>
+        <?php endif; ?>
        <li class="pc-item">
           <a href="../../dist/recetas/index.php" class="pc-link">
             <span class="pc-micon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
@@ -337,10 +337,10 @@ $notificationCount = count($notificaciones);
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
@@ -7,14 +7,9 @@ $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
 
-$sql = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt = $conexion->prepare($sql);
-$stmt->bind_param("i", $_SESSION['IdUsuario']);
-$stmt->execute();
-$resultadoNotificaciones = $stmt->get_result();
+require_once '../widget/notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 <!doctype html>
 <html lang="en">
@@ -101,7 +96,7 @@ $resultadoNotificaciones = $stmt->get_result();
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -253,7 +248,7 @@ $resultadoNotificaciones = $stmt->get_result();
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -272,43 +267,9 @@ $resultadoNotificaciones = $stmt->get_result();
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-      <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
     </li>
     <li class="dropdown pc-h-item header-user-profile">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once '../auth/check_session.php';
 $IdUsuario=$_SESSION['IdUsuario'];
 include('../widget/db.php');
 include('../forms/UsuarioClass.php');
@@ -150,14 +150,16 @@ $resultadoNotificaciones = $stmt->get_result();
             <span class="pc-mtext">Mi Progreso</span>
           </a>
         </li>
+        <?php if(isset($_SESSION['IdRol']) && $_SESSION['IdRol'] == 2): ?>
         <li class="pc-item">
           <a href="../../dist/widget/w_paneladm.php" class="pc-link">
             <span class="pc-micon">
-              <img src="../assets/images/icons-tab/icons9.png" alt="Recetas">  
+              <img src="../assets/images/icons-tab/icons9.png" alt="Recetas">
             </span>
             <span class="pc-mtext">Panel de Administración</span>
           </a>
        </li>
+        <?php endif; ?>
        <li class="pc-item">
           <a href="../../dist/recetas/index.php" class="pc-link">
             <span class="pc-micon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
@@ -340,10 +340,10 @@ $notificationCount = count($notificaciones);
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
@@ -7,14 +7,9 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
-$sql = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt = $conexion->prepare($sql);
-$stmt->bind_param("i", $_SESSION['IdUsuario']);
-$stmt->execute();
-$resultadoNotificaciones = $stmt->get_result();
+require_once '../widget/notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 <!doctype html>
 <html lang="es">
@@ -103,7 +98,7 @@ $resultadoNotificaciones = $stmt->get_result();
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -255,7 +250,7 @@ $resultadoNotificaciones = $stmt->get_result();
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -274,43 +269,9 @@ $resultadoNotificaciones = $stmt->get_result();
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge"><?=$resultadoNotificaciones->num_rows?></span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-  <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
       </div>
     </li>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
@@ -1,5 +1,5 @@
 <?php
-session_start();
+require_once '../auth/check_session.php';
 $IdUsuario = $_SESSION['IdUsuario'];
 include('../widget/db.php');
 include('../forms/UsuarioClass.php');

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
@@ -318,10 +318,10 @@ $notificationCount = count($notificaciones);
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
@@ -7,14 +7,9 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
-$sql = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt = $conexion->prepare($sql);
-$stmt->bind_param("i", $_SESSION['IdUsuario']);
-$stmt->execute();
-$resultadoNotificaciones = $stmt->get_result();
+require_once '../widget/notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 <!doctype html>
 <html lang="es">
@@ -86,7 +81,7 @@ $resultadoNotificaciones = $stmt->get_result();
                     <i class="ph-duotone ph-sneaker-move f-28"></i>
                     <span>Plan de entrenamiento</span>
                   </a>
-                  <a href="#!">
+                  <a href="../auth/logout.php">
                     <i class="ti ti-power"></i>
                     <span>Cerrar Sesión</span>
                   </a>
@@ -234,7 +229,7 @@ $resultadoNotificaciones = $stmt->get_result();
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -253,43 +248,9 @@ $resultadoNotificaciones = $stmt->get_result();
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-      <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
     </li>
     <li class="dropdown pc-h-item header-user-profile">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_save.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_save.php
@@ -1,4 +1,5 @@
 <?php
+require_once '../../auth/check_admin.php';
   if (!empty($_SERVER['HTTPS']) && ('on' == $_SERVER['HTTPS'])) {
     $uri = 'https://';
 } else {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_update.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_update.php
@@ -1,4 +1,5 @@
 <?php
+require_once '../../auth/check_admin.php';
   if (!empty($_SERVER['HTTPS']) && ('on' == $_SERVER['HTTPS'])) {
     $uri = 'https://';
 } else {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
@@ -118,7 +118,7 @@
 
     function fetchIngredientes() {
         $.ajax({
-            url: '../api/ingredientes.php',
+            url: 'api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
@@ -84,7 +84,7 @@
     var ingredientes = [];
 
     $(document).ready(function () {
-        fetchIngredientes(addIngrediente);
+        fetchIngredientes();
 
         $('#btnAddIngrediente').on('click', function () {
             addIngrediente();
@@ -116,14 +116,13 @@
         $('#ingredientesList').append(ingredienteItem);
     }
 
-    function fetchIngredientes(callback = null) {
+    function fetchIngredientes() {
         $.ajax({
             url: '../api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) {
                 ingredientes = JSON.parse(response);
-                if (typeof callback === 'function') callback();
             },
             error: function (xhr, status, error) {
                 console.error("Ocurrió un error al obtener los ingredientes: " + error);

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
@@ -84,7 +84,7 @@
     var ingredientes = [];
 
     $(document).ready(function () {
-        fetchIngredientes();
+        fetchIngredientes(addIngrediente);
 
         $('#btnAddIngrediente').on('click', function () {
             addIngrediente();
@@ -116,13 +116,14 @@
         $('#ingredientesList').append(ingredienteItem);
     }
 
-    function fetchIngredientes() {
+    function fetchIngredientes(callback = null) {
         $.ajax({
             url: 'api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) {
                 ingredientes = JSON.parse(response);
+                if (typeof callback === 'function') callback();
             },
             error: function (xhr, status, error) {
                 console.error("Ocurrió un error al obtener los ingredientes: " + error);

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_create.php
@@ -118,7 +118,7 @@
 
     function fetchIngredientes(callback = null) {
         $.ajax({
-            url: 'api/ingredientes.php',
+            url: '../api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_list.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_list.php
@@ -73,8 +73,10 @@
                     <div class="col-md-3 mb-3">
                         <div class="" style="position: relative; top: 40%;">
                             <button type="button" class="btn btn-primary" onclick="fetchRecetas(1)">Aplicar Filtros</button>
-                            <a href="./nueva-receta.php" type="button" class="btn btn-secondary"> + Nuevo</a>
-                        </div> 
+                            <?php if(isset($_SESSION['IdRol']) && $_SESSION['IdRol'] == 2): ?>
+                                <a href="./nueva-receta.php" type="button" class="btn btn-secondary"> + Nuevo</a>
+                            <?php endif; ?>
+                        </div>
                     </div>
                 </div>
                 
@@ -94,6 +96,7 @@
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script>
+    var isAdmin = <?php echo (isset($_SESSION['IdRol']) && $_SESSION['IdRol'] == 2) ? 'true' : 'false'; ?>;
     function fetchRecetas(page = 1) {
         const filtros = $('#filtrosForm').serialize() + `&page=${page}`; 
         $.ajax({
@@ -133,7 +136,7 @@
                                 <a href="#" class="link-ver-mas">Ver más</a>` : ''}
                             <p><strong>Tiempo:</strong> ${receta.tiempo_preparacion} mins</p>
                             <p><strong>Dificultad:</strong> ${receta.dificultad}</p>
-                            <a href="./editar-receta.php?id=${receta.id}" class="btn btn-primary">Editar</a>
+                            ${isAdmin ? `<a href="./editar-receta.php?id=${receta.id}" class="btn btn-primary">Editar</a>` : ''}
                         </div>
                     </div>
                 </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
@@ -138,7 +138,7 @@
 
     function fetchIngredientes() { 
         $.ajax({
-            url: '../api/ingredientes.php',
+            url: 'api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) { 
@@ -149,7 +149,7 @@
 
     function fetchOneReceta() { 
     $.ajax({
-        url: '../api/recetas_one.php?id=<?php echo $_GET['id'] ?>',
+        url: 'api/recetas_one.php?id=<?php echo $_GET['id'] ?>',
         type: 'GET',
         data: null,
         success: function (response) { 

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
@@ -81,9 +81,8 @@
     var receta ={};
 
     $(document).ready(function () {
-       fetchIngredientes(function(){
-           fetchOneReceta();
-       });
+       fetchIngredientes(); 
+       fetchOneReceta();
 
         // Agregar un nuevo ingrediente
         $('#btnAddIngrediente').on('click', function () {
@@ -137,14 +136,13 @@
         $('#ingredientesList').append(ingredienteItem);
     }
 
-    function fetchIngredientes(callback = null) {
+    function fetchIngredientes() { 
         $.ajax({
             url: '../api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) { 
-                ingredientes = JSON.parse(response);
-                if (typeof callback === 'function') callback();
+                ingredientes = JSON.parse(response); 
             }
         });
     }

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
@@ -81,8 +81,9 @@
     var receta ={};
 
     $(document).ready(function () {
-       fetchIngredientes(); 
-       fetchOneReceta();
+       fetchIngredientes(function(){
+           fetchOneReceta();
+       });
 
         // Agregar un nuevo ingrediente
         $('#btnAddIngrediente').on('click', function () {
@@ -136,13 +137,14 @@
         $('#ingredientesList').append(ingredienteItem);
     }
 
-    function fetchIngredientes() { 
+    function fetchIngredientes(callback = null) {
         $.ajax({
             url: './api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) { 
-                ingredientes = JSON.parse(response); 
+                ingredientes = JSON.parse(response);
+                if (typeof callback === 'function') callback();
             }
         });
     }

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/contents/receta_update.php
@@ -139,7 +139,7 @@
 
     function fetchIngredientes(callback = null) {
         $.ajax({
-            url: './api/ingredientes.php',
+            url: '../api/ingredientes.php',
             type: 'GET',
             data: null,
             success: function (response) { 
@@ -151,7 +151,7 @@
 
     function fetchOneReceta() { 
     $.ajax({
-        url: './api/recetas_one.php?id=<?php echo $_GET['id'] ?>',
+        url: '../api/recetas_one.php?id=<?php echo $_GET['id'] ?>',
         type: 'GET',
         data: null,
         success: function (response) { 

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/editar-receta.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/editar-receta.php
@@ -1,10 +1,9 @@
 <?php
-
+require_once '../auth/check_admin.php';
 
 if (!isset($_GET['id'])) {
     header('Location: '.$uri.'/ori-fit/able-pro-vanila-bootstrap-9.4.3/dist/recetas/');
 }
-
 
 $content = 'contents/receta_update.php';
 $title = "Editar Receta";

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/nueva-receta.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/nueva-receta.php
@@ -1,4 +1,5 @@
 <?php
+require_once '../auth/check_admin.php';
 $content = 'contents/receta_create.php';
 $title = "Nueva Receta";
 include('../layouts/layout.php');

--- a/able-pro-vanila-bootstrap-9.4.3/dist/sql_files/database.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/sql_files/database.php
@@ -1,23 +1,28 @@
 <?php
 class Database {
-    public $host = 'localhost';
+    private $host = 'localhost';
     private $db_name = 'testing';
     private $username = 'root';
     private $password = '';
-    public $conn;
+    private $conn;
 
-    // Método para conectar a la base de datos
     public function getConnection() {
-        $this->conn = null;
+        if ($this->conn) return $this->conn;
+
+        $dsn  = "mysql:host={$this->host};dbname={$this->db_name};charset=utf8mb4";
+        $opts = [
+            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES   => false,
+            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8mb4"
+        ];
 
         try {
-            $this->conn = new PDO("mysql:host=" . $this->host . ";dbname=" . $this->db_name, $this->username, $this->password);
-            $this->conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        } catch (PDOException $exception) {
-            echo "Error en la conexión: " . $exception->getMessage();
+            $this->conn = new PDO($dsn, $this->username, $this->password, $opts);
+        } catch (PDOException $e) {
+            throw new Exception("Error en la conexión: " . $e->getMessage());
         }
 
         return $this->conn;
     }
 }
-?>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/validacion-login.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/validacion-login.php
@@ -36,6 +36,7 @@ if (isset($input['email']) && isset($input['password'])) {
                     // Iniciar sesión
                     session_start();
                     $_SESSION['IdUsuario'] = $user['id'];
+                    $_SESSION['IdRol'] = $user['idRol'];
                     
                     $response['success'] = true;
                     $response['message'] = 'Ingreso exitoso.';

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/borrar_usuario.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/borrar_usuario.php
@@ -1,5 +1,6 @@
 <?php
 include 'db.php';
+require_once '../auth/check_admin.php';
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     // Recibir el ID del usuario a borrar

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/calcula_ejercicios.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/calcula_ejercicios.php
@@ -1,6 +1,6 @@
 <?php
 include 'db.php';
-session_start();
+require_once '../auth/check_session.php';
 
 // 1) Usuario y solicitud
 $usuario_id = $_SESSION['IdUsuario'];

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/notifications.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/notifications.php
@@ -1,0 +1,51 @@
+<?php
+function get_notifications(mysqli $conexion): array {
+    if (!isset($_SESSION['IdUsuario'])) return [];
+    $sql = "SELECT n.Titulo, n.descripcion, pu.pregunta
+            FROM notificaciones n
+            JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
+            WHERE n.IdUsuario = ?";
+    $stmt = $conexion->prepare($sql);
+    if (!$stmt) return [];
+    $stmt->bind_param("i", $_SESSION['IdUsuario']);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $data = $res ? $res->fetch_all(MYSQLI_ASSOC) : [];
+    $stmt->close();
+    return $data;
+}
+
+function render_notifications_dropdown(array $notificaciones): void {?>
+    <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
+      <div class="dropdown-header d-flex align-items-center justify-content-between">
+        <h5 class="m-0">Notificaciones</h5>
+        <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
+      </div>
+      <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
+        <?php if (!empty($notificaciones)): ?>
+          <?php foreach ($notificaciones as $n): ?>
+            <div class="card mb-2">
+              <div class="card-body">
+                <div class="d-flex">
+                  <div class="flex-shrink-0">
+                    <svg class="pc-icon text-primary"><use xlink:href="#custom-layer"></use></svg>
+                  </div>
+                  <div class="flex-grow-1 ms-3">
+                    <h4 class="text-body mb-2"><?= htmlspecialchars($n['Titulo']) ?></h4>
+                    <p>Pregunta:<?= $n['pregunta'] ?></p>
+                    <h5 class="mb-0"><?= htmlspecialchars($n['descripcion']) ?></h5>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <?php endforeach; ?>
+        <?php else: ?>
+          <p class="text-center">No hay notificaciones</p>
+        <?php endif; ?>
+      </div>
+      <div class="text-center py-2">
+        <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
+      </div>
+    </div>
+<?php }
+?>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
@@ -136,14 +136,9 @@ $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
 $solicitud=$usuario->ObtenerSolicitud($_SESSION['IdUsuario']);
 
-$sql56 = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt23 = $conexion->prepare($sql56);
-$stmt23->bind_param("i", $_SESSION['IdUsuario']);
-$stmt23->execute();
-$resultadoNotificaciones = $stmt23->get_result();
+require_once 'notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 function getYoutubeId(string $url): ?string {
     // soporta youtu.be/, watch?v=, embed/
     if (preg_match(
@@ -267,7 +262,7 @@ function getYoutubeId(string $url): ?string {
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -418,7 +413,7 @@ function getYoutubeId(string $url): ?string {
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -437,43 +432,9 @@ function getYoutubeId(string $url): ?string {
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-      <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
     </li>
     <li class="dropdown pc-h-item header-user-profile">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
@@ -502,10 +502,10 @@ function getYoutubeId(string $url): ?string {
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
@@ -80,8 +80,9 @@ if ($result_solicitud && $result_solicitud->num_rows > 0) {
     $agrupado_por_dia = [];
   }
 }else {
-    echo "⚠️ No se encontró ninguna solicitud para este usuario.<br>";
-    $agrupado_por_dia = [];
+  header('Location: ../pages/Panel.php');
+  $calorias = $proteinas = $grasas = $carbohidratos = 0;
+  $alimentos = [];
 }
 
 function generarSeriesYRepeticiones($nivel, $tiempo, $dias) {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
@@ -4,15 +4,11 @@
 include 'db.php';
 
 // Iniciar la sesión para obtener datos de usuario
-session_start();
+require_once '../auth/check_session.php';
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
-if (!isset($_SESSION['IdUsuario'])) {
-    echo "⚠️ ERROR: sesión no iniciada correctamente.";
-    exit;
-}
 
 // $usuario_id = $_SESSION['usuario_id']; // Captura el id de la sesión del usuario (para pruebas está hardcodeado)
 //$usuario_id = 1;  ID de usuario hardcodeado para pruebas

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
@@ -427,10 +427,10 @@ $notificationCount = count($notificaciones);
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
@@ -4,7 +4,7 @@
 include 'db.php';
 
 // Iniciar la sesión para obtener datos de usuario
-session_start();
+require_once '../auth/check_session.php';
 
 // $usuario_id = $_SESSION['usuario_id']; // Captura el id de la sesión del usuario (para pruebas está hardcodeado)
 //$usuario_id = 1;  ID de usuario hardcodeado para pruebas

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
@@ -94,14 +94,9 @@ $solicitud=$usuario->ObtenerSolicitud($_SESSION['IdUsuario']);
 $comidas=explode("-",$solicitud[0]["comidas"]);
 
 
-$sql56 = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt23 = $conexion->prepare($sql56);
-$stmt23->bind_param("i", $_SESSION['IdUsuario']);
-$stmt23->execute();
-$resultadoNotificaciones = $stmt23->get_result();
+require_once 'notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 
 <!doctype html>
@@ -192,7 +187,7 @@ $resultadoNotificaciones = $stmt23->get_result();
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -343,7 +338,7 @@ $resultadoNotificaciones = $stmt23->get_result();
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -362,43 +357,9 @@ $resultadoNotificaciones = $stmt23->get_result();
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-      <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
     </li>
     <li class="dropdown pc-h-item header-user-profile">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
@@ -420,10 +420,10 @@ function getYoutubeId(string $url): ?string {
             </a>
             <hr class="border-secondary border-opacity-50" />
             <div class="d-grid mb-3">
-              <button class="btn btn-primary">
-                <svg class="pc-icon me-2">  
+              <a href="../auth/logout.php" class="btn btn-primary">
+                <svg class="pc-icon me-2">
                   <use xlink:href="#custom-logout-1-outline"></use></svg>Logout
-              </button>
+              </a>
             </div>
             
           </div>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
@@ -30,14 +30,9 @@ $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
 
-$sql = "SELECT n.Titulo, n.descripcion, pu.pregunta
-        FROM notificaciones n
-        JOIN preguntasusuarios pu ON n.idpregunta = pu.idpregunta
-        WHERE n.IdUsuario = ?";
-$stmt = $conexion->prepare($sql);
-$stmt->bind_param("i", $_SESSION['IdUsuario']);
-$stmt->execute();
-$resultadoNotificaciones = $stmt->get_result();
+require_once 'notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 
 
 function getYoutubeId(string $url): ?string {
@@ -185,7 +180,7 @@ function getYoutubeId(string $url): ?string {
                 <i class="ph-duotone ph-sneaker-move f-28"></i>
                 <span>Plan de entrenamiento</span>
               </a>
-              <a href="#!">
+              <a href="../auth/logout.php">
                 <i class="ti ti-power"></i>
                 <span>Cerrar Sesión</span>
               </a>
@@ -336,7 +331,7 @@ function getYoutubeId(string $url): ?string {
           <i class="ti ti-user"></i>
           <span>Mis Planes</span>
         </a>
-        <a href="#!" class="dropdown-item">
+        <a href="../auth/logout.php" class="dropdown-item">
           <i class="ti ti-power"></i>
           <span>Cerrar Sesión</span>
         </a>
@@ -355,43 +350,9 @@ function getYoutubeId(string $url): ?string {
         <svg class="pc-icon">
           <use xlink:href="#custom-notification"></use>
         </svg>
-        <span class="badge bg-success pc-h-badge">3</span>
+        <span class="badge bg-success pc-h-badge"><?=$notificationCount?></span>
       </a>
-      <div class="dropdown-menu dropdown-notification dropdown-menu-end pc-h-dropdown">
-      <div class="dropdown-header d-flex align-items-center justify-content-between">
-    <h5 class="m-0">Notificaciones</h5>
-    <a href="#!" class="btn btn-link btn-sm">Marcar como leidas</a>
-  </div>
-  <div class="dropdown-body text-wrap header-notification-scroll position-relative" style="max-height: calc(100vh - 215px)">
-    <?php if($resultadoNotificaciones->num_rows > 0): ?>
-      <?php while($notificacion = $resultadoNotificaciones->fetch_assoc()): ?>
-        <div class="card mb-2">
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="flex-shrink-0">
-                <svg class="pc-icon text-primary">
-                  <use xlink:href="#custom-layer"></use>
-                </svg>
-              </div>
-              <div class="flex-grow-1 ms-3">
-                <span class="float-end text-sm text-muted">
-                </span>
-                <h4 class="text-body mb-2"><?= htmlspecialchars($notificacion['Titulo']); ?></h4>
-                <p>Pregunta:<?=$notificacion['pregunta']?></p>
-                <h5 class="mb-0"><?= htmlspecialchars($notificacion['descripcion']); ?></h5>
-              </div>
-            </div>
-          </div>
-        </div>
-      <?php endwhile; ?>
-    <?php else: ?>
-      <p class="text-center">No hay notificaciones</p>
-    <?php endif; ?>
-  </div>
-  <div class="text-center py-2">
-    <a href="#!" class="link-danger">Borrar todas las Notificaciones</a>
-  </div>
-</div>
+      <?php render_notifications_dropdown($notificaciones); ?>
 
     </li>
     <li class="dropdown pc-h-item header-user-profile">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
@@ -1,6 +1,6 @@
   <?php
 include('db.php'); // Incluye la conexión a la base de datos
-session_start();
+require_once '../auth/check_admin.php';
 
 // Obtener listado de equipamientos para los formularios
 $equipResult = $conexion->query("SELECT IdEquipamiento, Equipamiento FROM equipamiento ORDER BY IdEquipamiento");


### PR DESCRIPTION
## Summary
- add common session and admin guards
- store user role in session after login
- protect dashboard and layout by requiring login
- hide admin links for non‑admins
- restrict recipe management and admin pages to admin role
- validate plan generation date

## Testing
- `php -l $(git ls-files '*.php')`

------
https://chatgpt.com/codex/tasks/task_e_688013f4c3508326b18b1cc60014fb43