### PR TITLE
Fix recipe ingredient queries

### DIFF
--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/ingredientes.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/ingredientes.php
@@ -7,10 +7,13 @@ ini_set('display_errors', 1);
 try {
     require_once '../../sql_files/database.php';
 
-    $database = new Database(); 
+    $database = new Database();
     $conn = $database->getConnection();
+    if ($conn === null) {
+        throw new Exception('DB connection failed');
+    }
 
-    $sql = "SELECT IdIngrediente, Nombre, Gramos_Proteina, Calorias, Gramos_Grasas FROM ingredientes";
+    $sql = "SELECT id AS IdIngrediente, nombre AS Nombre, proteinas AS Gramos_Proteina, calorias AS Calorias, grasas AS Gramos_Grasas FROM ingredientes";
 
     // Preparar y ejecutar la consulta
     $stmt = $conn->prepare($sql);

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_one.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_one.php
@@ -14,8 +14,11 @@ try{
 
 require_once '../../sql_files/database.php';
 
-$database = new Database(); 
-$conn = $database->getConnection(); 
+$database = new Database();
+$conn = $database->getConnection();
+if ($conn === null) {
+    throw new Exception('DB connection failed');
+}
 
 $id = $_GET['id'] ?? '';
 
@@ -48,7 +51,7 @@ echo json_encode( $receta);
 
 $conn = null;
 
-}catch(e){
-    //echo "Ocurrió un error: " . $e->getMessage();
+}catch(Exception $e){
+    echo "Ocurrió un error: " . $e->getMessage();
 }
 ?>

--- a/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_paginacion.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_paginacion.php
@@ -9,6 +9,9 @@ try {
 
     $database = new Database();
     $conn = $database->getConnection();
+    if ($conn === null) {
+        throw new Exception('DB connection failed');
+    }
 
     // Parámetros de entrada
     $titulo = $_GET['titulo'] ?? '';
@@ -24,7 +27,7 @@ try {
         SELECT DISTINCT r.* 
         FROM recetas r
         LEFT JOIN recetas_ingredientes ri ON r.id = ri.receta_id
-        LEFT JOIN ingredientes i ON ri.ingrediente_id = i.IdIngrediente  -- Corregido aquí
+        LEFT JOIN ingredientes i ON ri.ingrediente_id = i.id
         WHERE 1=1
     ";
 
@@ -68,7 +71,7 @@ try {
         SELECT COUNT(DISTINCT r.id) as total 
         FROM recetas r
         LEFT JOIN recetas_ingredientes ri ON r.id = ri.receta_id
-        LEFT JOIN ingredientes i ON ri.ingrediente_id = i.IdIngrediente  -- Corregido aquí también
+        LEFT JOIN ingredientes i ON ri.ingrediente_id = i.id
         WHERE 1=1
     ";
     if (!empty($titulo)) {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/sql_files/database.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/sql_files/database.php
@@ -14,7 +14,7 @@ class Database {
             $this->conn = new PDO("mysql:host=" . $this->host . ";dbname=" . $this->db_name, $this->username, $this->password);
             $this->conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (PDOException $exception) {
-            echo "Error en la conexión: " . $exception->getMessage();
+            throw new Exception("Error en la conexión: " . $exception->getMessage());
         }
 
         return $this->conn;


### PR DESCRIPTION
## Summary
- correct column names in `ingredientes.php`
- fix joins in recipe pagination
- clean error handling and remove mock JSON

## Testing
- `php -l able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/ingredientes.php`
- `php -l able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_one.php`
- `php -l able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/recetas_paginacion.php`
- `php -l able-pro-vanila-bootstrap-9.4.3/dist/sql_files/database.php`
- `php able-pro-vanila-bootstrap-9.4.3/dist/recetas/api/ingredientes.php` *(fails to connect, shows DB error)*

------
https://chatgpt.com/codex/tasks/task_e_68803bcb9c3083268d5c7878a1569045