### PR TITLE
Add SweetAlert confirmation for user deletion

### DIFF
--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/add_user.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/add_user.php
@@ -5,24 +5,26 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     // Recibir los datos del formulario
     $nombre = isset($_POST['nombre']) ? trim($_POST['nombre']) : '';
     $apellido = isset($_POST['apellido']) ? trim($_POST['apellido']) : '';
-    // Edad es opcional, se guarda como 0 si no se proporciona
-    $edad = isset($_POST['edad']) ? intval($_POST['edad']) : 0;
     $telefono = isset($_POST['telefono']) ? trim($_POST['telefono']) : '';
     $correo = isset($_POST['correo']) ? trim($_POST['correo']) : '';
+    $password = isset($_POST['password']) ? $_POST['password'] : '';
     $plan = isset($_POST['plan']) ? intval($_POST['plan']) : 0;
     $rol = isset($_POST['rol']) ? intval($_POST['rol']) : 0;
     // Convertir el checkbox de acceso a un valor numérico (1=Habilitado, 2=Deshabilitado)
     $acceso = isset($_POST['acceso']) && $_POST['acceso'] === 'permitido' ? 1 : 2;
 
     // Validar campos obligatorios
-    if (empty($nombre) || empty($apellido) || empty($telefono) || empty($correo) || empty($plan) || empty($rol)) {
+    if (empty($nombre) || empty($apellido) || empty($telefono) || empty($correo) || empty($password) || empty($plan) || empty($rol)) {
         echo "Todos los campos son obligatorios.";
         exit();
     }
 
+    $hashed_password = password_hash($password, PASSWORD_DEFAULT);
+    $fecha = date("Y-m-d");
+
     try {
         // Preparar consulta para insertar el nuevo usuario
-        $query = "INSERT INTO usuarios (nombre, apellido, edad, telefono, correo, acceso, idTipoPlan, idRol) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        $query = "INSERT INTO usuarios (nombre, apellido, correo, password, idRol, acceso, telefono, fecha_registro, idTipoPlan) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
         $stmt = $conexion->prepare($query);
 
         if (!$stmt) {
@@ -30,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         }
 
         // Asignar parámetros
-        $stmt->bind_param("ssissiii", $nombre, $apellido, $edad, $telefono, $correo, $acceso, $plan, $rol);
+        $stmt->bind_param("ssssiiisi", $nombre, $apellido, $correo, $hashed_password, $rol, $acceso, $telefono, $fecha, $plan);
 
         // Ejecutar consulta
         if ($stmt->execute()) {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/add_user.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/add_user.php
@@ -5,15 +5,17 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     // Recibir los datos del formulario
     $nombre = isset($_POST['nombre']) ? trim($_POST['nombre']) : '';
     $apellido = isset($_POST['apellido']) ? trim($_POST['apellido']) : '';
+    // Edad es opcional, se guarda como 0 si no se proporciona
     $edad = isset($_POST['edad']) ? intval($_POST['edad']) : 0;
     $telefono = isset($_POST['telefono']) ? trim($_POST['telefono']) : '';
     $correo = isset($_POST['correo']) ? trim($_POST['correo']) : '';
     $plan = isset($_POST['plan']) ? intval($_POST['plan']) : 0;
     $rol = isset($_POST['rol']) ? intval($_POST['rol']) : 0;
-    $acceso = isset($_POST['acceso']) && $_POST['acceso'] === 'permitido' ? 'Habilitado' : 'Deshabilitado';
+    // Convertir el checkbox de acceso a un valor numérico (1=Habilitado, 2=Deshabilitado)
+    $acceso = isset($_POST['acceso']) && $_POST['acceso'] === 'permitido' ? 1 : 2;
 
     // Validar campos obligatorios
-    if (empty($nombre) || empty($apellido) || empty($telefono) || empty($correo) || empty($edad) || empty($plan) || empty($rol)) {
+    if (empty($nombre) || empty($apellido) || empty($telefono) || empty($correo) || empty($plan) || empty($rol)) {
         echo "Todos los campos son obligatorios.";
         exit();
     }
@@ -28,7 +30,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         }
 
         // Asignar parámetros
-        $stmt->bind_param("ssisssii", $nombre, $apellido, $edad, $telefono, $correo, $acceso, $plan, $rol);
+        $stmt->bind_param("ssissiii", $nombre, $apellido, $edad, $telefono, $correo, $acceso, $plan, $rol);
 
         // Ejecutar consulta
         if ($stmt->execute()) {

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/borrar_usuario.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/borrar_usuario.php
@@ -108,12 +108,22 @@ try {
     $stmt->close();
 
     $conexion->commit();
-    header("Location: w_paneladm.php?#usuarios");
+    if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest') {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => true]);
+    } else {
+        header("Location: w_paneladm.php?#usuarios");
+    }
     exit;
 } catch (Exception $e) {
     $conexion->rollback();
-    http_response_code(500);
-    echo "Error: " . $e->getMessage();
+    if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest') {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+    } else {
+        http_response_code(500);
+        echo "Error: " . $e->getMessage();
+    }
 } finally {
     $conexion->close();
 }

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
@@ -1109,6 +1109,11 @@ td.limit-text {
                     </div>
 
                     <div class="mb-3">
+                        <label for="addPassword" class="form-label">Contraseña</label>
+                        <input type="password" class="form-control" id="addPassword" name="password" required>
+                    </div>
+
+                    <div class="mb-3">
                         <label class="form-label">Acceso</label>
                         <div class="form-check form-switch">
                             <input class="form-check-input" type="checkbox" id="addAcceso" name="acceso" value="permitido">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
@@ -1036,7 +1036,7 @@ td.limit-text {
                     </thead>
                     <tbody>
                         <?php foreach ($usuarios as $usuario): ?>
-                            <tr>
+                            <tr id="user-row-<?= $usuario['id'] ?>">
                                 <td><?php echo $usuario['id']; ?></td>
                                 <td><?php echo $usuario['nombre']; ?></td>
                                 <td class="d-none d-md-table-cell"><?php echo $usuario['apellido']; ?></td>
@@ -1061,12 +1061,13 @@ td.limit-text {
                                           <img src="../assets/images/icons-tab/editar.png" alt="Editar" style="width: 16px; height: 16px;">
                                       </button>
 
-                                        <form method="POST" action="borrar_usuario.php" style="display: inline;">
-                                            <input type="hidden" name="id" value="<?php echo $usuario['id']; ?>">
-                                            <button type="submit" class="btn btn-danger btn-sm w-100 w-md-auto" title="Eliminar Usuario">
+                                        <button
+                                            type="button"
+                                            class="btn btn-danger btn-sm w-100 w-md-auto btn-delete-user"
+                                            data-idusuario="<?= $usuario['id'] ?>"
+                                            title="Eliminar Usuario">
                                                 <img src="../assets/images/icons-tab/papelera.png" alt="Eliminar" style="width: 16px; height: 16px;">
-                                            </button>
-                                        </form>
+                                        </button>
                                     </div>
                                 </td>
                             </tr>
@@ -2890,6 +2891,45 @@ window.onload = function () {
         console.error('Error de red:', error);
     }
 }
+</script>
+<script>
+// Eliminación de usuarios con confirmación SweetAlert
+document.querySelectorAll('.btn-delete-user').forEach(btn => {
+    btn.addEventListener('click', () => {
+        const id = btn.dataset.idusuario;
+        Swal.fire({
+            title: '¿Eliminar usuario?',
+            text: 'Esta acción no se puede deshacer',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar'
+        }).then(result => {
+            if (result.isConfirmed) {
+                const fd = new FormData();
+                fd.append('id', id);
+                fetch('borrar_usuario.php', {
+                    method: 'POST',
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    body: fd
+                })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.success) {
+                        Swal.fire('Eliminado', 'El usuario ha sido borrado', 'success');
+                        const row = document.getElementById("user-row-" + id);
+                        if (row) row.remove();
+                    } else {
+                        Swal.fire('Error', data.message || 'No se pudo eliminar', 'error');
+                    }
+                })
+                .catch(() => {
+                    Swal.fire('Error', 'No se pudo eliminar', 'error');
+                });
+            }
+        });
+    });
+});
 </script>
 <script>
 // Eliminación de videos con confirmación SweetAlert


### PR DESCRIPTION
## Summary
- confirm deleting a user with SweetAlert
- support AJAX responses in `borrar_usuario.php`

## Testing
- `php -l dist/widget/w_paneladm.php`
- `php -l dist/widget/borrar_usuario.php`


------
https://chatgpt.com/codex/tasks/task_e_6880fa74f2688326b7988478f03808e7