### PR TITLE
Mostrar rol de usuario según idRol y corregir redirecciones

### DIFF
--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/alimentosForm.php
@@ -6,7 +6,13 @@ require_once '../auth/check_session.php';
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
-
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
 
 require_once '../widget/notifications.php';
 $notificaciones = get_notifications($conexion);
@@ -100,7 +106,7 @@ $notificationCount = count($notificaciones);
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/cuestionariohecho.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/cuestionariohecho.php
@@ -8,7 +8,24 @@
 
 
 <?php
+include('db.php');
+include('UsuarioClass.php');
+require_once '../auth/check_session.php';
 
+$usuario = new Usuario($conexion);
+$datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
+
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
+
+require_once '../widget/notifications.php';
+$notificaciones = get_notifications($conexion);
+$notificationCount = count($notificaciones);
 ?>
 <!doctype html>
 <html lang="es">
@@ -80,8 +97,8 @@
               <img src="../assets/images/user/avatar-9.jpg" alt="user-image" class="user-avtar wid-45 rounded-circle" />
             </div>
             <div class="flex-grow-1 ms-3 me-2">
-              <h6 class="mb-0">Oriana Cristiano</h6>
-              <small>Administrador</small>
+              <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
+              <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/forms/ejerciciosForm.php
@@ -6,6 +6,14 @@ require_once '../auth/check_session.php';
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
+
 // Determinar si se debe saltar la primera pestaña en caso de plan mixto
 $saltarDatosPersonales = ($datosUsuario["idTipoPlan"] == 3);
 require_once '../widget/notifications.php';
@@ -78,7 +86,7 @@ $notificationCount = count($notificaciones);
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/foro/respuestaForo.php
@@ -7,6 +7,13 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
 
 $usuarioPreguntaId = filter_input(INPUT_GET, 'idpregunta', FILTER_VALIDATE_INT);
 if (!$usuarioPreguntaId) {
@@ -79,7 +86,7 @@ if ($row = $result->fetch_assoc()) {
                 </div>
                 <div class="flex-grow-1 ms-3 me-2">
                   <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-                  <small>Administrador</small>
+                  <small><?= $rolUsuario ?></small>
                 </div>
                 <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
                   <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/layouts/layout.php
@@ -6,6 +6,13 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
 
 require_once '../widget/notifications.php';
 $notificaciones = get_notifications($conexion);
@@ -78,7 +85,7 @@ $notificationCount = count($notificaciones);
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/panel.php
@@ -7,6 +7,14 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+ $roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
+
 require_once '../widget/notifications.php';
 $notificaciones = get_notifications($conexion);
 $notificationCount = count($notificaciones);
@@ -80,7 +88,7 @@ $notificationCount = count($notificaciones);
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/pages/recomendations.php
@@ -7,6 +7,14 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+ $roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
+
 require_once '../widget/notifications.php';
 $notificaciones = get_notifications($conexion);
 $notificationCount = count($notificaciones);
@@ -63,7 +71,7 @@ $notificationCount = count($notificaciones);
                 </div>
                 <div class="flex-grow-1 ms-3 me-2">
                   <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-                  <small>Administrador</small>
+                  <small><?= $rolUsuario ?></small>
                 </div>
                 <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
                   <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/panelrutina.php
@@ -86,7 +86,7 @@ if ($result_solicitud && $result_solicitud->num_rows > 0) {
     $agrupado_por_dia = [];
   }
 }else {
-  header('Location: ../pages/Panel.php');
+  header('Location: ../pages/panel.php');
   $calorias = $proteinas = $grasas = $carbohidratos = 0;
   $alimentos = [];
 }
@@ -140,6 +140,13 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
 
 $solicitud=$usuario->ObtenerSolicitud($_SESSION['IdUsuario']);
 
@@ -251,7 +258,7 @@ function getYoutubeId(string $url): ?string {
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_chart.php
@@ -86,7 +86,7 @@ if ($solicitud_id) {
           echo "No se encontraron alimentos para esta solicitud.";
       }
 } else {
-    header('Location: ../pages/Panel.php');
+    header('Location: ../pages/panel.php');
     $calorias = $proteinas = $grasas = $carbohidratos = 0;
     $alimentos = [];
 }
@@ -96,6 +96,13 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
 
 $solicitud=$usuario->ObtenerSolicitud($_SESSION['IdUsuario']);
 
@@ -177,7 +184,7 @@ $notificationCount = count($notificaciones);
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">

--- a/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
+++ b/able-pro-vanila-bootstrap-9.4.3/dist/widget/w_paneladm.php
@@ -29,6 +29,13 @@ include('../forms/UsuarioClass.php');
 $usuario = new Usuario($conexion);
 $datosUsuario = $usuario->obtenerPorId($_SESSION['IdUsuario']);
 
+$roles = [
+    1 => 'Usuario',
+    2 => 'Administrador',
+    3 => 'Especialista en Entrenamiento',
+    4 => 'Especialista en Nutrición'
+];
+$rolUsuario = $roles[$datosUsuario['idRol']] ?? 'Rol Desconocido';
 
 require_once 'notifications.php';
 $notificaciones = get_notifications($conexion);
@@ -162,7 +169,7 @@ function getYoutubeId(string $url): ?string {
             </div>
             <div class="flex-grow-1 ms-3 me-2">
             <h6 class="mb-0"><?= ucwords($datosUsuario['nombre']) ?> <?= ucwords($datosUsuario['apellido']) ?></h6>
-            <small>Administrador</small>
+            <small><?= $rolUsuario ?></small>
             </div>
             <a class="btn btn-icon btn-link-secondary avtar" data-bs-toggle="collapse" href="#pc_sidebar_userlink">
               <svg class="pc-icon">


### PR DESCRIPTION
## Summary
- Actualiza todas las redirecciones que apuntaban a `Panel.php` para usar `panel.php`
- Muestra el rol del usuario en el sidebar de acuerdo a su `idRol`

## Testing
- `php -l dist/widget/w_chart.php dist/widget/panelrutina.php dist/pages/recomendations.php dist/pages/panel.php dist/foro/respuestaForo.php dist/layouts/layout.php dist/widget/w_paneladm.php dist/forms/alimentosForm.php dist/forms/ejerciciosForm.php dist/forms/cuestionariohecho.php`

------
https://chatgpt.com/codex/tasks/task_e_689a0ba1d80c83268390b0994e2c43c3